### PR TITLE
Revert "Updated job queue to python 3"

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -14,7 +14,7 @@ class Neon(RodanTask):
     name = 'Neon'
     author = 'Juliette Regimbal & Zoe McLennan'
     description = 'Neume Editor Online'
-    settings = {'job_queue': 'Python3'}
+    settings = {'job_queue': 'Python2'}
     enabled = True
     category = 'Pitch Correction'
     interactive = True


### PR DESCRIPTION
Reverts DDMAL/neon_wrapper#46 - should have been merged into `develop`, not `master`