### PR TITLE
Update neon wrapper to python 3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 MIT License
 
-Copyright (c) 2018 Juliette Regimbal, Zoé McLennan
+Copyright (c) 2018 Zoé McLennan,
+              2018-2019 Alex Daigle,
+              2018-2019 Gabriel Vigliensoni,
+              2018-2020 Juliette Regimbal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Juliette Regimbal, Zoé McLennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "1.0.0"
 from rodan.jobs import module_loader
 
-module_loader('rodan.jobs.neon-wrapper.wrapper')
+module_loader('rodan.jobs.neon_wrapper.wrapper')

--- a/editor.html
+++ b/editor.html
@@ -3,11 +3,9 @@
   <head>
     <title>Neon</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.10.0/d3.min.js" integrity="sha256-Sx36P52/SeHWhm86q2b4uGB4FLu/aFPyBQqggucUvao=" crossorigin="anonymous"></script>
-    <script src="./Neon/assets/diva-v6.0.1/diva.js"></script>
     <script src="https://unpkg.com/bulma-slider@2.0.0/dist/js/bulma-slider.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.css"/>
     <link rel="stylesheet" href="https://unpkg.com/bulma-slider@2.0.0/dist/css/bulma-slider.min.css"/>
-    <link rel="stylesheet" href="./Neon/assets/diva-v6.0.1/diva.css"/>
     <link rel="stylesheet" href="./Neon/assets/style.css"/>
   </head>
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -9,7 +9,7 @@ class Neon(RodanTask):
     name = 'Neon'
     author = 'Juliette Regimbal & Zoe McLennan'
     description = 'Neume Editor Online'
-    settings = {'job_queue': 'Python2'}
+    settings = {'job_queue': 'Python3'}
     enabled = True
     category = 'Pitch Correction'
     interactive = True


### PR DESCRIPTION
Necessary to go along with the recent changes in Rodan as neon is now registered as a python 3 job.